### PR TITLE
Use powershell.exe instead of clip.exe to copy to WSL clipboard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clipboard-anywhere"
 description = "Copy text to the clipboard, even in WSL and SSH sessions"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 authors = ["Reilly Wood"]
 repository = "https://github.com/rgwood/clipboard-anywhere"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A simple wrapper around [`arboard`](https://github.com/1Password/arboard) that works in a few more situations:
 
-- In Linux under WSL, it can copy to and from the Windows clipboard (using `clip.exe` and `powershell get-clipboard`)
+- In Linux under WSL, it can copy to and from the Windows clipboard (using `powershell set-clipboard` and `powershell get-clipboard`)
 - In a remote SSH session, can copy to the local clipboard using the OSC 52 control sequence
 
 ## Usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,10 +55,20 @@ fn set_clipboard_osc_52(text: &str) {
 
 /// Set the Windows clipboard using powershell.exe in WSL
 fn set_wsl_clipboard(s: &str) -> anyhow::Result<()> {
+    // In PowerShell, we can escape literal single-quotes
+    // in a single-quoted string by doubling them, e.g.
+    //
+    // 'hello ''world'''
+    //
+    // gets printed as
+    //
+    // hello 'world'
+    let escaped_s = s.replace("'", "''");
+
     let mut powershell = Command::new("powershell.exe")
         .arg("-NoProfile")
         .arg("-Command")
-        .arg(&format!("Set-Clipboard -Value \"{}\"", s))
+        .arg(&format!("Set-Clipboard -Value '{}'", escaped_s))
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 use std::{
     env,
-    io::Write,
     process::{Command, Stdio},
 };
 
@@ -54,15 +53,14 @@ fn set_clipboard_osc_52(text: &str) {
     print!("\x1B]52;c;{}\x07", base64::encode(text));
 }
 
-/// Set the Windows clipboard using clip.exe in WSL
+/// Set the Windows clipboard using powershell.exe in WSL
 fn set_wsl_clipboard(s: &str) -> anyhow::Result<()> {
-    let mut clipboard = Command::new("clip.exe").stdin(Stdio::piped()).spawn()?;
-    let mut clipboard_stdin = clipboard
-        .stdin
-        .take()
-        .ok_or_else(|| anyhow::anyhow!("Could not get stdin handle for clip.exe"))?;
-
-    clipboard_stdin.write_all(s.as_bytes())?;
+    let _ = Command::new("powershell.exe")
+        .arg("-command")
+        .arg(&format!("Set-Clipboard -Value \"{}\"", s))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,12 +55,16 @@ fn set_clipboard_osc_52(text: &str) {
 
 /// Set the Windows clipboard using powershell.exe in WSL
 fn set_wsl_clipboard(s: &str) -> anyhow::Result<()> {
-    let _ = Command::new("powershell.exe")
-        .arg("-command")
+    let mut powershell = Command::new("powershell.exe")
+        .arg("-NoProfile")
+        .arg("-Command")
         .arg(&format!("Set-Clipboard -Value \"{}\"", s))
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()?;
+
+    // Wait until the powershell process is finished before returning
+    powershell.wait()?;
 
     Ok(())
 }


### PR DESCRIPTION
## Problem

Copying to clipboard in WSL environment using `clip.exe` leads to garbled data being copied to clipboard for Unicode point characters (e.g. 💯). Using `powershell.exe set-clipboard` instead copies Unicode point characters to the clipboard correctly.

## Evidence

I have a crate that I put together for fun called [`emojicp`](https://crates.io/crates/clipboard-anywhere). I liked your crate because it gave me the widest number of environments to run `emojicp` in. However, it seems to fail for WSL environments.

Below are 10 emojis that I tried to copy to my clipboard in WSL alongside what was actually copied to my clipboard:

| Emoji Name          | Expected Output | Expected Output (Hex) | Actual Output |      Actual Output (Hex)      |
| ------------------- | :-------------: | :-------------------: | :-----------: | :---------------------------: |
| white_check_mark    |       ✅        |       e2 9c 85        |      Γ£à      |       ce 93 c2 a3 c3 a0       |
| santa               |       🎅        |      f0 9f 8e 85      |     ≡ƒÄà      |  e2 89 a1 c6 92 c3 84 c3 a0   |
| monkey              |       🐒        |      f0 9f 90 92      |     ≡ƒÉÆ      |  e2 89 a1 c6 92 c3 89 c3 86   |
| see_no_evil         |       🙈        |      f0 9f 99 88      |     ≡ƒÖê      |  e2 89 a1 c6 92 c3 96 c3 aa   |
| hear_no_evil        |       🙉        |      f0 9f 99 89      |     ≡ƒÖë      |  e2 89 a1 c6 92 c3 96 c3 ab   |
| speak_no_evil       |       🙊        |      f0 9f 99 8a      |     ≡ƒÖè      |  e2 89 a1 c6 92 c3 96 c3 a8   |
| monkey_face         |       🐵        |      f0 9f 90 b5      |     ≡ƒÉ╡      | e2 89 a1 c6 92 c3 89 e2 95 a1 |
| sunglasses          |       😎        |      f0 9f 98 8e      |     ≡ƒÿÄ      |  e2 89 a1 c6 92 c3 bf c3 84   |
| oncoming_automobile |       🚘        |      f0 9f 9a 98      |     ≡ƒÜÿ      |  e2 89 a1 c6 92 c3 9c c3 bf   |
| orangutan           |       🦧        |      f0 9f a6 a7      |     ≡ƒªº      |  e2 89 a1 c6 92 c2 aa c2 ba   |
| japanese_goblin     |       👺        |      f0 9f 91 ba      |     ቡƒæ║      | e1 89 a1 c6 92 c3 a6 e2 95 91 |

## Solution

After reading a lot of obscure [WSL GitHub issues](https://github.com/tmux-plugins/tmux-yank/issues/144#issuecomment-1499888009) and playing around with encodings, the only solution that actually fixed my use case was replacing `clip.exe` with `powershell.exe set-clipboard` altogether. Now, with `powershell.exe set-clipboard`, I can copy emojis to my clipboard in WSL just fine.